### PR TITLE
Define CLI commands that are easier to use

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'api/**'
+      - 'api/openapi/**'
       - '.github/workflows/api.yml'
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <h2>DevDB - On-demand, isolated databases for development and testing</h2>
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-0530AD.svg)](https://opensource.org/licenses/Apache-2.0)
-![Platform Support](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-E5DDD4)
+![Platform Support](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-E5DDD4)
 [![API Tests](https://github.com/meido-ai/devdb/actions/workflows/api.yml/badge.svg)](https://github.com/meido-ai/devdb/actions/workflows/api.yml)
 [![CLI Tests](https://github.com/meido-ai/devdb/actions/workflows/cli.yml/badge.svg)](https://github.com/meido-ai/devdb/actions/workflows/cli.yml)
 [![CLI Version](https://img.shields.io/github/v/release/meido-ai/devdb?color=4D148C&label=cli&logo=github)](https://github.com/meido-ai/devdb/releases/latest)
@@ -61,7 +61,7 @@ move devdb.exe %USERPROFILE%\bin\devdb.exe
 ```bash
 # Configure the CLI
 export DEVDB_API=$(kubectl get svc -n devdb devdb-api -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
-devdb config set-server http://$DEVDB_API
+devdb context use http://$DEVDB_API
 
 # Create a project
 devdb project create --name my-project

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,12 +1,27 @@
 ## 📖 Common Operations
 
+### Context
+```bash
+# Set the DevDB server URL
+devdb context use http://localhost:3000
+
+# Display the current DevDB server
+devdb context show
+```
+
 ### Project Management
 ```bash
 # List projects
 devdb project list
 
 # Create a new project
-devdb project create --name my-project --owner myteam
+devdb project create --name my-project
+
+# Set the project's database type and version
+devdb project set --project my-project --type postgres --version 15.3
+
+# Get the current project configuration
+devdb project show --project my-project
 
 # Delete a project
 devdb project delete my-project


### PR DESCRIPTION


## 🤖 AI Summary

- Modified `.github/workflows/api.yml` to include `api/openapi/**` in the list of paths that trigger the API workflow
- Updated `README.md`:
    - Changed the platform support badge to remove Linux
    - Updated the command to set the DevDB server URL in the CLI configuration example
- Modified `docs/cli.md`:
    - Added new section for context management commands
    - Simplified the `project create` command example
    - Added examples for setting the project's database type and version
    - Added an example for showing the current project configuration