### PR TITLE
Bundle App as ES Module

### DIFF
--- a/api/jest.config.cjs
+++ b/api/jest.config.cjs
@@ -1,8 +1,17 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
   testMatch: ['**/*.test.ts'],
   moduleFileExtensions: ['ts', 'js', 'json', 'node'],
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+      },
+    ],
+  },
 };

--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,7 @@
     "build:test": "tsc -p tsconfig.test.json",
     "generate:types": "openapi-typescript openapi/openapi.yaml -o src/types/generated/api.ts",
     "pretest": "npm run build:test",
-    "test": "jest"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.cjs"
   },
   "author": "",
   "license": "ISC",

--- a/api/package.json
+++ b/api/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "DevDB API Server",
   "main": "src/app.ts",
+  "type": "module",
   "scripts": {
     "start": "ts-node src/app.ts",
     "dev": "nodemon src/app.ts",

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "module": "commonjs",
+    "target": "es2020",
+    "module": "es2020",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/charts/devdb/Chart.yaml
+++ b/charts/devdb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: devdb
 description: A Helm chart to install and upgrade DevDB
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.0.0"


### PR DESCRIPTION
Fixes the Common JS import failure at startup:

```sh
/app/dist/app.js:51
const client_node_1 = require("@kubernetes/client-node");
                      ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /app/node_modules/@kubernetes/client-node/dist/index.js from /app/dist/app.js not supported.
Instead change the require of index.js in /app/dist/app.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/app/dist/app.js:51:23) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v18.20.5
```

## 🤖 AI Summary

- Renamed `api/jest.config.cjs` and made changes to support ES modules
- Modified `api/package.json` to set `"type": "module"` and update the `"test"` script to use `node` with the `--experimental-vm-modules` flag
- Updated compiler options in `api/tsconfig.json` to use `"target": "es2020"` and `"module": "es2020"`
- Incremented the chart version in `charts/devdb/Chart.yaml` from `0.1.0` to `0.1.1`